### PR TITLE
Add Prometheus metrics integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ build/
 # Ignore OS files
 .DS_Store
 Thumbs.db
+__pycache__/
+backend/**/__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # flintsky_residence
+
+## Metrics
+
+The backend exposes Prometheus metrics at `/metrics`. Install the
+`kube-prometheus-stack` Helm chart to collect them and visualise in
+Grafana:
+
+```bash
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm install prometheus-stack prometheus-community/kube-prometheus-stack
+kubectl apply -f k8s/
+```
+
+After deployment, Grafana will pick up the `ServiceMonitor` and you can
+create dashboards based on the exported metrics.

--- a/backend/booking/views.py
+++ b/backend/booking/views.py
@@ -1,6 +1,7 @@
 from rest_framework import generics
 from .models import Apartment, Booking
 from .serializers import ApartmentSerializer, BookingSerializer
+from backend.metrics import bookings_created_total
 
 class ApartmentList(generics.ListAPIView):
     queryset = Apartment.objects.all()
@@ -9,4 +10,9 @@ class ApartmentList(generics.ListAPIView):
 class BookingCreate(generics.CreateAPIView):
     queryset = Booking.objects.all()
     serializer_class = BookingSerializer
+
+    def perform_create(self, serializer):
+        instance = serializer.save()
+        bookings_created_total.inc()
+        return instance
 

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -31,6 +31,7 @@ ALLOWED_HOSTS = ['*']
 # Application definition
 
 INSTALLED_APPS = [
+    "django_prometheus",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -42,6 +43,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -49,6 +51,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "django_prometheus.middleware.PrometheusAfterMiddleware",
 ]
 
 ROOT_URLCONF = "core.urls"

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -4,6 +4,7 @@ from django.urls import path, include
 
 urlpatterns = [
     path('', lambda request: JsonResponse({"message":"Flintsky Backend is running"})),
+    path('', include('django_prometheus.urls')),
     path("admin/", admin.site.urls),
     path('api/', include('booking.urls')),
 ]

--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -1,0 +1,6 @@
+from prometheus_client import Counter
+
+bookings_created_total = Counter(
+    'bookings_created_total',
+    'Total number of bookings created'
+)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,5 @@ asgiref==3.9.1
 Django==5.2.4
 djangorestframework==3.16.0
 sqlparse==0.5.3
+django-prometheus==2.3.1
+prometheus-client==0.20.0

--- a/k8s/django-service.yaml
+++ b/k8s/django-service.yaml
@@ -2,11 +2,16 @@ apiVersion: v1
 kind: Service
 metadata:
   name: django-service
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8000"
+    prometheus.io/path: "/metrics"
 spec:
   selector:
     app: django
   ports:
-    - protocol: TCP
+    - name: http
+      protocol: TCP
       port: 8000
       targetPort: 8000
   type: ClusterIP

--- a/k8s/django-servicemonitor.yaml
+++ b/k8s/django-servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: django-servicemonitor
+  labels:
+    release: prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app: django
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 15s


### PR DESCRIPTION
## Summary
- expose `/metrics` using `django-prometheus`
- count created bookings using a Prometheus counter
- expose metrics via Kubernetes service and ServiceMonitor
- document metrics stack deployment

## Testing
- `pip install -r backend/requirements.txt`
- `python backend/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687a2dfb4f7c83218ecad02f0bd64d95